### PR TITLE
Ignore React Fragments

### DIFF
--- a/index.js
+++ b/index.js
@@ -64,10 +64,11 @@ function isTreeDone(node, excludeComponentNames) {
 
 function isSubtreeDone(node) {
   return (
-    node.type === 'JSXElement' &&
-    node.openingElement.attributes.find(
-      (attributeNode) => attributeNode.name?.name === 'data-component',
-    )
+    node.type === 'JSXFragment' ||
+    (node.type === 'JSXElement' &&
+      node.openingElement.attributes.find(
+        (attributeNode) => attributeNode.name?.name === 'data-component',
+      ))
   );
 }
 


### PR DESCRIPTION
There is no way to add a data-component attribute to a fragment, and this plugin skipped the fragment ad added the data-component attribute to the children of the fragment. This commit ignores fragments when they are the return statement and does not require a data component.